### PR TITLE
comment deprecated apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A comprehensive binding to the ffmpeg video/audio manipulation library.
 
 `````go
 
-import "github.com/LeoKingLong/goav/avformat"
+import "github.com/leokinglong/goav/avformat"
 
 func main() {
 
@@ -70,7 +70,7 @@ export LD_LIBRARY_PATH=$HOME/ffmpeg/lib
 ``` 
 
 ``` 
-go get github.com/LeoKingLong/goav
+go get github.com/leokinglong/goav
 
 ``` 
 

--- a/avcodec/bitstreamfilter.go
+++ b/avcodec/bitstreamfilter.go
@@ -6,31 +6,28 @@ package avcodec
 //#cgo pkg-config: libavcodec
 //#include <libavcodec/avcodec.h>
 import "C"
-import (
-	"unsafe"
-)
 
 //Register a bitstream filter.
-func (b *BitStreamFilter) AvRegisterBitstreamFilter() {
-	C.av_register_bitstream_filter((*C.struct_AVBitStreamFilter)(b))
-}
+// func (b *BitStreamFilter) AvRegisterBitstreamFilter() {
+// 	C.av_register_bitstream_filter((*C.struct_AVBitStreamFilter)(b))
+// }
 
 //BitStreamFilter *av_bitstream_filter_next (const BitStreamFilter *f)
-func (f *BitStreamFilter) AvBitstreamFilterNext() *BitStreamFilter {
-	return (*BitStreamFilter)(C.av_bitstream_filter_next((*C.struct_AVBitStreamFilter)(f)))
-}
+// func (f *BitStreamFilter) AvBitstreamFilterNext() *BitStreamFilter {
+// 	return (*BitStreamFilter)(C.av_bitstream_filter_next((*C.struct_AVBitStreamFilter)(f)))
+// }
 
 //Filter bitstream.
-func (bfx *BitStreamFilterContext) AvBitstreamFilterFilter(ctxt *Context, a string, p **uint8, ps *int, b *uint8, bs, k int) int {
-	return int(C.av_bitstream_filter_filter((*C.struct_AVBitStreamFilterContext)(bfx), (*C.struct_AVCodecContext)(ctxt), C.CString(a), (**C.uint8_t)(unsafe.Pointer(p)), (*C.int)(unsafe.Pointer(ps)), (*C.uint8_t)(b), C.int(bs), C.int(k)))
-}
+// func (bfx *BitStreamFilterContext) AvBitstreamFilterFilter(ctxt *Context, a string, p **uint8, ps *int, b *uint8, bs, k int) int {
+// 	return int(C.av_bitstream_filter_filter((*C.struct_AVBitStreamFilterContext)(bfx), (*C.struct_AVCodecContext)(ctxt), C.CString(a), (**C.uint8_t)(unsafe.Pointer(p)), (*C.int)(unsafe.Pointer(ps)), (*C.uint8_t)(b), C.int(bs), C.int(k)))
+// }
 
 //Release bitstream filter context.
-func (bfx *BitStreamFilterContext) AvBitstreamFilterClose() {
-	C.av_bitstream_filter_close((*C.struct_AVBitStreamFilterContext)(bfx))
-}
+// func (bfx *BitStreamFilterContext) AvBitstreamFilterClose() {
+// 	C.av_bitstream_filter_close((*C.struct_AVBitStreamFilterContext)(bfx))
+// }
 
 //Create and initialize a bitstream filter context given a bitstream filter name.
-func AvBitstreamFilterInit(n string) *BitStreamFilterContext {
-	return (*BitStreamFilterContext)(C.av_bitstream_filter_init(C.CString(n)))
-}
+// func AvBitstreamFilterInit(n string) *BitStreamFilterContext {
+// 	return (*BitStreamFilterContext)(C.av_bitstream_filter_init(C.CString(n)))
+// }

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -17,7 +17,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/LeoKingLong/goav/avcodec"
+	"github.com/leokinglong/goav/avcodec"
 )
 
 type (

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -21,8 +21,8 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/LeoKingLong/goav/avcodec"
-	"github.com/LeoKingLong/goav/avutil"
+	"github.com/leokinglong/goav/avcodec"
+	"github.com/leokinglong/goav/avutil"
 )
 
 type (

--- a/avformat/codec_context_struct.go
+++ b/avformat/codec_context_struct.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/LeoKingLong/goav/avcodec"
+	"github.com/leokinglong/goav/avcodec"
 )
 
 func (cctxt *CodecContext) Type() MediaType {

--- a/avformat/context.go
+++ b/avformat/context.go
@@ -10,8 +10,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/LeoKingLong/goav/avcodec"
-	"github.com/LeoKingLong/goav/avutil"
+	"github.com/leokinglong/goav/avcodec"
+	"github.com/leokinglong/goav/avutil"
 )
 
 const (

--- a/avformat/context_struct.go
+++ b/avformat/context_struct.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/LeoKingLong/goav/avutil"
+	"github.com/leokinglong/goav/avutil"
 )
 
 func (ctxt *Context) Chapters() **AvChapter {

--- a/avformat/packet.go
+++ b/avformat/packet.go
@@ -9,7 +9,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/LeoKingLong/goav/avcodec"
+	"github.com/leokinglong/goav/avcodec"
 )
 
 func toCPacket(pkt *avcodec.Packet) *C.struct_AVPacket {

--- a/avformat/rational.go
+++ b/avformat/rational.go
@@ -6,7 +6,7 @@ package avformat
 //#cgo pkg-config: libavutil
 //#include <libavutil/avutil.h>
 import "C"
-import "github.com/LeoKingLong/goav/avcodec"
+import "github.com/leokinglong/goav/avcodec"
 
 func newRational(r C.struct_AVRational) avcodec.Rational {
 	return avcodec.NewRational(int(r.num), int(r.den))

--- a/avformat/stream.go
+++ b/avformat/stream.go
@@ -7,7 +7,7 @@ package avformat
 //#include <libavformat/avformat.h>
 import "C"
 import (
-	"github.com/LeoKingLong/goav/avcodec"
+	"github.com/leokinglong/goav/avcodec"
 )
 
 //Rational av_stream_get_r_frame_rate (const Stream *s)

--- a/avformat/stream_struct.go
+++ b/avformat/stream_struct.go
@@ -9,9 +9,9 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/LeoKingLong/goav/avutil"
+	"github.com/leokinglong/goav/avutil"
 
-	"github.com/LeoKingLong/goav/avcodec"
+	"github.com/leokinglong/goav/avcodec"
 )
 
 func (avs *Stream) CodecParameters() *avcodec.AvCodecParameters {

--- a/example/tutorial01.go
+++ b/example/tutorial01.go
@@ -25,10 +25,10 @@ import (
 	"os"
 	"unsafe"
 
-	"github.com/LeoKingLong/goav/avcodec"
-	"github.com/LeoKingLong/goav/avformat"
-	"github.com/LeoKingLong/goav/avutil"
-	"github.com/LeoKingLong/goav/swscale"
+	"github.com/leokinglong/goav/avcodec"
+	"github.com/leokinglong/goav/avformat"
+	"github.com/leokinglong/goav/avutil"
+	"github.com/leokinglong/goav/swscale"
 )
 
 // SaveFrame writes a single frame to disk as a PPM file

--- a/example/versions.go
+++ b/example/versions.go
@@ -3,11 +3,11 @@ package main
 import (
 	"log"
 
-	"github.com/LeoKingLong/goav/avdevice"
-	"github.com/LeoKingLong/goav/avfilter"
-	"github.com/LeoKingLong/goav/avutil"
-	"github.com/LeoKingLong/goav/swresample"
-	"github.com/LeoKingLong/goav/swscale"
+	"github.com/leokinglong/goav/avdevice"
+	"github.com/leokinglong/goav/avfilter"
+	"github.com/leokinglong/goav/avutil"
+	"github.com/leokinglong/goav/swresample"
+	"github.com/leokinglong/goav/swscale"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/LeoKingLong/goav
+module github.com/leokinglong/goav
 
 go 1.16
 


### PR DESCRIPTION
1. comment deprecated apis.
2. rename with lowercase to avoid linux dir name problem.